### PR TITLE
Adds environment deployments through tunnel service

### DIFF
--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -9,6 +9,7 @@ on:
 env:
   COMPOSE_FILE: docker-compose.yml
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+concurrency: docker_compose_ngrok_free
 jobs:
   simple-docker-compose:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
@@ -16,6 +17,18 @@ jobs:
       deployments: write
     runs-on: ubuntu-latest
     steps:
+
+      - name: "Check if user has write access"
+        uses: "lannonbr/repo-permission-check-action@2.0.0"
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: codetalkio/expose-tunnel@v1.4.0
         id: expose_ngrok
         with:
-          service: bore.pub
+          service: localhost.run
           port: 80
 
       - name: Update deployment status (success)

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sleep after cancel
+        run: sleep 30s
+        shell: bash
+
       - uses: chrnorm/deployment-action@v2.0.5
         name: Create GitHub deployment
         id: deployment

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -55,17 +55,6 @@ jobs:
 #          ngrok_authtoken: ${{ secrets.NGROK_TOKEN }}
 #          tunnel_type: http
 
-      - uses: codetalkio/expose-tunnel@v1.4.0
-        id: expose_ngrok
-        with:
-          service: bore.pub
-          port: 80
-
-      - name: Test Ngrok fail
-        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
-        run: exit 1
-        shell: bash
-
       - name: Update deployment status (failure)
         if: failure()
         uses: chrnorm/deployment-status@v2.0.1
@@ -107,6 +96,18 @@ jobs:
         with:
           message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: codetalkio/expose-tunnel@v1.4.0
+        id: expose_ngrok
+        with:
+          service: bore.pub
+          port: 80
+          blocking: 60m
+
+      - name: Test Ngrok fail
+        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
+        run: exit 1
+        shell: bash
 
 #      - name: Sleep
 #        run: docker-compose logs -f

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -3,6 +3,7 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
+# test1
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -46,17 +46,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run establish a ngrok tunnel
+#      - name: Run establish a ngrok tunnel
+#        id: expose_ngrok
+#        uses: wikiteq/ngrok-tunneling-action@master
+#        with:
+#          timeout: 1h
+#          port: 80
+#          ngrok_authtoken: ${{ secrets.NGROK_TOKEN }}
+#          tunnel_type: http
+
+      - uses: codetalkio/expose-tunnel@v1.4.0
         id: expose_ngrok
-        uses: wikiteq/ngrok-tunneling-action@master
         with:
-          timeout: 1h
+          service: bore.pub
           port: 80
-          ngrok_authtoken: ${{ secrets.NGROK_TOKEN }}
-          tunnel_type: http
 
       - name: Test Ngrok fail
-        if: ${{ steps.expose_ngrok.outputs.TUNNEL_URL == '' }}
+        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
         run: exit 1
         shell: bash
 
@@ -72,7 +78,7 @@ jobs:
         run: cp .env.ci .env
 
       - name: Update server variable
-        run: echo "MW_SITE_SERVER=${{ steps.expose_ngrok.outputs.TUNNEL_URL }}" >> .env
+        run: echo "MW_SITE_SERVER=${{ steps.expose_ngrok.outputs.tunnel-url }}" >> .env
         shell: bash
 
       - name: Setup Docker Compose
@@ -90,21 +96,21 @@ jobs:
         if: success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}
+          environment-url: ${{ steps.expose_ngrok.outputs.tunnel-url }}
           state: 'success'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Comment on PR
-        if: ${{ steps.expose_ngrok.outputs.TUNNEL_URL != '' && github.event_name == 'pull_request' }}
+        if: ${{ steps.expose_ngrok.outputs.tunnel-url != '' && github.event_name == 'pull_request' }}
         uses: mshick/add-pr-comment@v2
         id: comment
         with:
-          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
+          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sleep
-        run: docker-compose logs -f
-        shell: bash
+#      - name: Sleep
+#        run: docker-compose logs -f
+#        shell: bash
 
       - name: Update deployment status (success)
         uses: chrnorm/deployment-status@v2.0.1

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -9,7 +9,7 @@ on:
 env:
   COMPOSE_FILE: docker-compose.yml
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
-concurrency: docker_compose_ngrok_free
+#concurrency: docker_compose_ngrok_free
 jobs:
   simple-docker-compose:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -87,13 +87,13 @@ jobs:
           state: 'success'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
-#      - name: Comment on PR
-#        if: ${{ steps.expose_ngrok.outputs.TUNNEL_URL != '' && github.event_name == 'pull_request' }}
-#        uses: mshick/add-pr-comment@v1
-#        id: comment
-#        with:
-#          message: "Deployed to ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}. Stay-alive time is 1 hour, re-run the action to re-deploy."
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment on PR
+        if: ${{ steps.expose_ngrok.outputs.TUNNEL_URL != '' && github.event_name == 'pull_request' }}
+        uses: mshick/add-pr-comment@v2
+        id: comment
+        with:
+          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remote the `deploy` label from the PR."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sleep
         run: docker-compose logs -f

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -3,7 +3,7 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
-# test1
+# test2
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -3,7 +3,7 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
-# test2
+# test3
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -3,7 +3,7 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
-# test4
+# test5
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -80,6 +80,12 @@ jobs:
         run: sleep 30s
         shell: bash
 
+      - uses: codetalkio/expose-tunnel@v1.4.0
+        id: expose_ngrok
+        with:
+          service: bore.pub
+          port: 80
+
       - name: Update deployment status (success)
         uses: chrnorm/deployment-status@v2.0.1
         if: success()
@@ -97,21 +103,14 @@ jobs:
           message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: codetalkio/expose-tunnel@v1.4.0
-        id: expose_ngrok
-        with:
-          service: bore.pub
-          port: 80
-          blocking: 60m
-
       - name: Test Ngrok fail
         if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
         run: exit 1
         shell: bash
 
-#      - name: Sleep
-#        run: docker-compose logs -f
-#        shell: bash
+      - name: Sleep
+        run: docker-compose logs -f
+        shell: bash
 
       - name: Update deployment status (success)
         uses: chrnorm/deployment-status@v2.0.1

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -3,7 +3,7 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
-# test3
+# test4
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -25,11 +25,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: chrnorm/deployment-action@v2
+      - uses: chrnorm/deployment-action@v2.0.5
         name: Create GitHub deployment
         id: deployment
         with:
@@ -55,7 +55,7 @@ jobs:
 
       - name: Update deployment status (failure)
         if: failure()
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@v2.0.5
         with:
           token: ${{ secrets.NGROK_TOKEN }}
           state: 'failure'
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@v2.0.5
         if: success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
         shell: bash
 
       - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2
+        uses: chrnorm/deployment-status@v2.0.5
         if: cancelled() || failure()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -66,7 +66,8 @@ jobs:
       - uses: codetalkio/expose-tunnel@v1.4.0
         id: expose_ngrok
         with:
-          service: localhost.run
+#          service: localhost.run
+          service: bore.pub
           port: 80
 
       - name: Test Ngrok fail

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -93,7 +93,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         id: comment
         with:
-          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remote the `deploy` label from the PR."
+          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.TUNNEL_URL }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sleep

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -63,6 +63,17 @@ jobs:
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
+      - uses: codetalkio/expose-tunnel@v1.4.0
+        id: expose_ngrok
+        with:
+          service: localhost.run
+          port: 80
+
+      - name: Test Ngrok fail
+        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
+        run: exit 1
+        shell: bash
+
       - name: Setup env
         run: cp .env.ci .env
 
@@ -80,12 +91,6 @@ jobs:
         run: sleep 30s
         shell: bash
 
-      - uses: codetalkio/expose-tunnel@v1.4.0
-        id: expose_ngrok
-        with:
-          service: localhost.run
-          port: 80
-
       - name: Update deployment status (success)
         uses: chrnorm/deployment-status@v2.0.1
         if: success()
@@ -102,11 +107,6 @@ jobs:
         with:
           message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Test Ngrok fail
-        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
-        run: exit 1
-        shell: bash
 
       - name: Sleep
         run: docker-compose logs -f

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Update deployment status (failure)
         if: failure()
-        uses: chrnorm/deployment-status@v2.0.5
+        uses: chrnorm/deployment-status@v2.0.1
         with:
           token: ${{ secrets.NGROK_TOKEN }}
           state: 'failure'
@@ -79,7 +79,7 @@ jobs:
         shell: bash
 
       - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2.0.5
+        uses: chrnorm/deployment-status@v2.0.1
         if: success()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
         shell: bash
 
       - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2.0.5
+        uses: chrnorm/deployment-status@v2.0.1
         if: cancelled() || failure()
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: true
 
       - name: Sleep
         run: docker-compose logs -f

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -106,7 +106,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         id: comment
         with:
-          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue to run until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
+          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue running until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: true
 

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 #    types: [ labeled ]
   workflow_call:
-    inputs: { }
-    secrets: { }
+    inputs: {}
+    secrets: {}
 env:
   COMPOSE_FILE: docker-compose.yml
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
@@ -17,9 +17,8 @@ jobs:
       deployments: write
     runs-on: ubuntu-latest
     steps:
-
-      - name: "Check if user has write access"
-        uses: "lannonbr/repo-permission-check-action@2.0.0"
+      - name: Check if user has write access
+        uses: lannonbr/repo-permission-check-action@2.0.2
         with:
           permission: "write"
         env:

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       deployments: write
       pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - name: Check if user has write access

--- a/.github/workflows/compose.yml
+++ b/.github/workflows/compose.yml
@@ -15,6 +15,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     permissions:
       deployments: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check if user has write access

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{github.event.pull_request.head.sha || github.sha}}
           repo: ${{ github.repository }}
-          checks: ${{ GITHUB_ACTION }}
+          checks: ${{ github.action }}
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
       deployments: write
       pull-requests: write
       actions: write
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: Run the action

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs: {}
     secrets: {}
-#concurrency: docker_compose_ngrok_free
+##concurrency: docker_compose_ngrok_free
 jobs:
   deploy-tunnel:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,10 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - name: Run the action
-        uses: Sibz/github-status-action@v1
+      - name: Update status
+        uses: ouzi-dev/commit-status-updater@v2
         with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          context: 'DeployerBot'
-          description: 'Passed'
-          state: 'success'
-          sha: ${{github.event.pull_request.head.sha || github.sha}}
+          status: "success"
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ env:
   BORE_TOKEN: ${{ secrets.BORE_TOKEN }}
 #concurrency: docker_compose_ngrok_free
 jobs:
-  simple-docker-compose:
+  deploy-tunnel:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     permissions:
       deployments: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,21 +30,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Echo check run ids
-        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).jobs.*.id) }}
+        run: echo "job ids - ${{ steps.fetch.outputs.data }}
 
-      - name: Confirm check
-        uses: LouisBrunner/checks-action@v1.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          conclusion: 'neutral'
-          name: 'deploy-tunnel'
-          status: 'completed'
+#      - name: Confirm check
+#        uses: LouisBrunner/checks-action@v1.1.1
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          conclusion: 'neutral'
+#          check_id: 'deploy-tunnel'
+#          status: 'completed'
 
-      - name: Deploy and tunnel
-        uses: wikiteq/compose-deploy-tunnel-action@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          secret: ${{ secrets.BORE_TOKEN }}
-          endpoint: stage-deploy.wikiteq.com
-          port: 80
-          file: docker-compose.yml
+#      - name: Deploy and tunnel
+#        uses: wikiteq/compose-deploy-tunnel-action@master
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          secret: ${{ secrets.BORE_TOKEN }}
+#          endpoint: stage-deploy.wikiteq.com
+#          port: 80
+#          file: docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Confirm check
-        uses: maael/confirm-checks-action@master
+        uses: maael/confirm-checks-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,14 +27,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Cancel Previous Runs
+#        uses: styfle/cancel-workflow-action@0.11.0
+#        with:
+#          access_token: ${{ secrets.GITHUB_TOKEN }}
+#          workflow_id: DeployerBot,deploy,deploy.yml
 
-      - name: Sleep after cancel
-        run: sleep 30s
-        shell: bash
+#      - name: Sleep after cancel
+#        run: sleep 30s
+#        shell: bash
 
       - uses: chrnorm/deployment-action@v2.0.5
         name: Create GitHub deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,14 +17,11 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
-      - name: Test
-        run: echo ${{ secrets.BORE_TOKEN }}
-        shell: bash
-#      - name: Deploy and tunnel
-#        uses: wikiteq/compose-deploy-tunnel-action@master
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          secret: ${{ secrets.BORE_TOKEN }}
-#          endpoint: stage-deploy.wikiteq.com
-#          port: 80
-#          file: docker-compose.yml
+      - name: Deploy and tunnel
+        uses: wikiteq/compose-deploy-tunnel-action@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          secret: ${{ secrets.BORE_TOKEN }}
+          endpoint: stage-deploy.wikiteq.com
+          port: 80
+          file: docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy and tunnel
-        uses: wikiteq/compose-deploy-tunnel-action@v1
+        uses: wikiteq/compose-deploy-tunnel-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           secret: ${{ secrets.BORE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{github.event.pull_request.head.sha || github.sha}}
           repo: ${{ github.repository }}
-          checks: 'DeployerBot,deploy-tunnel'
+          checks: 'deploy-tunnel'
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,6 @@ on:
   workflow_call:
     inputs: {}
     secrets: {}
-env:
-  COMPOSE_FILE: docker-compose.yml
-  BORE_TOKEN: ${{ secrets.BORE_TOKEN }}
 #concurrency: docker_compose_ngrok_free
 jobs:
   deploy-tunnel:
@@ -20,103 +17,11 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
-      - name: Check for secrets
-        if: env.BORE_TOKEN == '' || env.BORE_TOKEN == null
-        run: echo 'BORE_TOKEN secret is missing' && exit 1
-
-      - name: Check if user has write access
-        uses: lannonbr/repo-permission-check-action@2.0.2
-        with:
-          permission: "write"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow_id: DeployerBot,deploy,deploy.yml
-
-      - name: Sleep after cancel
-        run: sleep 30s
-        shell: bash
-
-      - uses: chrnorm/deployment-action@v2.0.5
-        name: Create GitHub deployment
-        id: deployment
+      - name: Deploy and tunnel
+        uses: wikiteq/compose-deploy-tunnel-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: development
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Update deployment status (failure)
-        if: failure()
-        uses: chrnorm/deployment-status@v2.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          state: 'failure'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - uses: codetalkio/expose-tunnel@v1.4.0
-        id: expose_ngrok
-        with:
-#          service: localhost.run
-#          service: bore.pub
-          service: bore.selfhosted
-          port: 80
-          selfHostedEndpoint: stage-deploy.wikiteq.com
           secret: ${{ secrets.BORE_TOKEN }}
-
-      - name: Test Ngrok fail
-        if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
-        run: exit 1
-        shell: bash
-
-      - name: Setup env
-        run: cp .env.ci .env
-
-      - name: Update server variable
-        run: echo "MW_SITE_SERVER=${{ steps.expose_ngrok.outputs.tunnel-url }}" >> .env
-        shell: bash
-
-      - name: Setup Docker Compose
-        uses: yu-ichiro/spin-up-docker-compose-action@main
-        with:
-          file: ${{ env.COMPOSE_FILE }}
-          cache-key: simple-docker-compose
-
-      - name: Give containers a moment to init
-        run: sleep 30s
-        shell: bash
-
-      - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2.0.1
-        if: success()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment-url: ${{ steps.expose_ngrok.outputs.tunnel-url }}
-          state: 'success'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-      - name: Comment on PR
-        if: ${{ steps.expose_ngrok.outputs.tunnel-url != '' && github.event_name == 'pull_request' }}
-        uses: mshick/add-pr-comment@v2
-        id: comment
-        with:
-          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, new commits deployed automatically. The action will continue running until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-repeats: true
-
-      - name: Sleep
-        run: docker-compose logs -f
-        shell: bash
-
-      - name: Update deployment status (success)
-        uses: chrnorm/deployment-status@v2.0.1
-        if: cancelled() || failure()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          state: 'inactive'
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+          endpoint: stage-deploy.wikiteq.com
+          port: 80
+          file: docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           conclusion: 'success'
           name: 'deploy-tunnel'
-          status: 'in_progress'
+          status: 'completed'
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,9 @@ jobs:
               check_name: 'deploy-tunnel'
             })
 
+      - name: Get result
+        run: echo "${{steps.my-script.outputs.result}}"
+
       - name: Confirm check
         uses: LouisBrunner/checks-action@v1.1.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Echo check run ids
-        run: echo "job ids - ${{ steps.fetch.outputs.data }}
+        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).jobs.*.id) }}"
 
 #      - name: Confirm check
 #        uses: LouisBrunner/checks-action@v1.1.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ouzi-dev/commit-status-updater@v2
         with:
           status: "success"
+          name: ${GITHUB_WORKFLOW}
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,28 +33,28 @@ jobs:
       - name: Echo check run ids
         run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}"
 
-      - name: Script
-        uses: actions/github-script@v6
-        id: my-script
-        with:
-          result-encoding: string
-          retries: 1
-          script: |
-            github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              ref: context.ref,
-              repo: context.repo.repo,
-              check_name: 'deploy-tunnel'
-            })
-
-      - name: Get result
-        run: echo "${{steps.my-script.outputs.result}}"
+#      - name: Script
+#        uses: actions/github-script@v6
+#        id: my-script
+#        with:
+#          result-encoding: string
+#          retries: 1
+#          script: |
+#            github.rest.checks.listForRef({
+#              owner: context.repo.owner,
+#              ref: context.ref,
+#              repo: context.repo.repo,
+#              check_name: 'deploy-tunnel'
+#            })
+#
+#      - name: Get result
+#        run: echo "${{steps.my-script.outputs.result}}"
 
       - name: Confirm check
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          conclusion: 'success'
+          conclusion: 'neutral'
           check_id: ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}
           status: 'completed'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,19 +33,19 @@ jobs:
       - name: Echo check run ids
         run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}"
 
-#      - name: Confirm check
-#        uses: LouisBrunner/checks-action@v1.1.1
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          conclusion: 'neutral'
-#          check_id: 'deploy-tunnel'
-#          status: 'completed'
+      - name: Confirm check
+        uses: LouisBrunner/checks-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion: 'success'
+          check_id: ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}
+          status: 'completed'
 
-#      - name: Deploy and tunnel
-#        uses: wikiteq/compose-deploy-tunnel-action@master
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          secret: ${{ secrets.BORE_TOKEN }}
-#          endpoint: stage-deploy.wikiteq.com
-#          port: 80
-#          file: docker-compose.yml
+      - name: Deploy and tunnel
+        uses: wikiteq/compose-deploy-tunnel-action@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          secret: ${{ secrets.BORE_TOKEN }}
+          endpoint: stage-deploy.wikiteq.com
+          port: 80
+          file: docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,6 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - name: Update status
-        uses: ouzi-dev/commit-status-updater@v2
-        with:
-          status: "success"
-          name: ${GITHUB_WORKFLOW}
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ name: DeployerBot
 on:
   pull_request:
 #    types: [ labeled ]
-# test5
   workflow_call:
     inputs: {}
     secrets: {}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,13 @@ on:
 jobs:
   deploy-tunnel:
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
+    runs-on: ubuntu-latest
     permissions:
       deployments: write
       pull-requests: write
       actions: write
       statuses: write
       checks: write
-    runs-on: ubuntu-latest
     steps:
 
       - name: Fetch check run ids
@@ -31,7 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Echo check run ids
-        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs.*.id) }}"
+        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}"
 
 #      - name: Confirm check
 #        uses: LouisBrunner/checks-action@v1.1.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{github.event.pull_request.head.sha || github.sha}}
           repo: ${{ github.repository }}
-          checks: ${{ github.action }}
+          checks: 'DeployerBot,deploy-tunnel'
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,14 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
+      - name: Run the action
+        uses: Sibz/github-status-action@v1
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Test run'
+          description: 'Passed'
+          state: 'success'
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
 env:
   COMPOSE_FILE: docker-compose.yml
   NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
+  BORE_TOKEN: ${{ secrets.BORE_TOKEN }}
 #concurrency: docker_compose_ngrok_free
 jobs:
   simple-docker-compose:
@@ -68,8 +69,11 @@ jobs:
         id: expose_ngrok
         with:
 #          service: localhost.run
-          service: bore.pub
+#          service: bore.pub
+          service: bore.selfhosted
           port: 80
+          selfHostedEndpoint: 209.182.255.172
+          secret: ${{ secrets.BORE_TOKEN }}
 
       - name: Test Ngrok fail
         if: ${{ steps.expose_ngrok.outputs.tunnel-url == '' }}
@@ -107,7 +111,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         id: comment
         with:
-          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, re-run the action to re-deploy. The action will continue running until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
+          message: "The PR is deployed to ${{ steps.expose_ngrok.outputs.tunnel-url }}. Stay-alive time is 1 hour, new commits deployed automatically. The action will continue running until timeout or cancelled. To prevent future deployments remove the `deploy` label from the PR."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           allow-repeats: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
-          context: 'Test run'
+          context: 'DeployerBot'
           description: 'Passed'
           state: 'success'
           sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,15 @@ jobs:
         id: fetch
         uses: octokit/request-action@v2.x
         with:
-          route: GET /repos/{repo}/actions/runs/{run_id}/jobs
+          route: GET /repos/{repo}/commits/{sha}/check-runs
           repo: ${{ github.repository }}
           run_id: ${{ github.run_id }}
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Echo check run ids
-        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).jobs.*.id) }}"
+        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs.*.id) }}"
 
 #      - name: Confirm check
 #        uses: LouisBrunner/checks-action@v1.1.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
     secrets: {}
 env:
   COMPOSE_FILE: docker-compose.yml
-  NGROK_TOKEN: ${{ secrets.NGROK_TOKEN }}
   BORE_TOKEN: ${{ secrets.BORE_TOKEN }}
 #concurrency: docker_compose_ngrok_free
 jobs:
@@ -21,6 +20,10 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
+      - name: Check for secrets
+        if: env.BORE_TOKEN == '' || env.BORE_TOKEN == null
+        run: echo 'BORE_TOKEN secret is missing' && exit 1
+
       - name: Check if user has write access
         uses: lannonbr/repo-permission-check-action@2.0.2
         with:
@@ -28,15 +31,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.11.0
-#        with:
-#          access_token: ${{ secrets.GITHUB_TOKEN }}
-#          workflow_id: DeployerBot,deploy,deploy.yml
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_id: DeployerBot,deploy,deploy.yml
 
-#      - name: Sleep after cancel
-#        run: sleep 30s
-#        shell: bash
+      - name: Sleep after cancel
+        run: sleep 30s
+        shell: bash
 
       - uses: chrnorm/deployment-action@v2.0.5
         name: Create GitHub deployment
@@ -48,20 +51,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-#      - name: Run establish a ngrok tunnel
-#        id: expose_ngrok
-#        uses: wikiteq/ngrok-tunneling-action@master
-#        with:
-#          timeout: 1h
-#          port: 80
-#          ngrok_authtoken: ${{ secrets.NGROK_TOKEN }}
-#          tunnel_type: http
-
       - name: Update deployment status (failure)
         if: failure()
         uses: chrnorm/deployment-status@v2.0.1
         with:
-          token: ${{ secrets.NGROK_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           state: 'failure'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -72,7 +66,7 @@ jobs:
 #          service: bore.pub
           service: bore.selfhosted
           port: 80
-          selfHostedEndpoint: 209.182.255.172
+          selfHostedEndpoint: stage-deploy.wikiteq.com
           secret: ${{ secrets.BORE_TOKEN }}
 
       - name: Test Ngrok fail
@@ -126,7 +120,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           state: 'inactive'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-
-#      - name: Sleep
-#        run: sleep 3600s
-#        shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,13 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
+      - name: Confirm check
+        uses: maael/confirm-checks-action
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{github.event.pull_request.head.sha || github.sha}}
+          repo: ${{ github.repository }}
+          checks: ${{ GITHUB_ACTION }}
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,20 @@ jobs:
       - name: Echo check run ids
         run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}"
 
+      - name: Script
+        uses: actions/github-script@v6
+        id: my-script
+        with:
+          result-encoding: string
+          retries: 1
+          script: |
+            github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              ref: context.ref,
+              repo: context.repo.repo,
+              check_name: 'deploy-tunnel'
+            })
+
       - name: Confirm check
         uses: LouisBrunner/checks-action@v1.1.1
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,3 +66,12 @@ jobs:
           endpoint: stage-deploy.wikiteq.com
           port: 80
           file: docker-compose.yml
+
+      - name: Confirm check
+        uses: LouisBrunner/checks-action@v1.1.1
+        if: cancelled() || failure()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion: 'neutral'
+          check_id: ${{ toJSON(fromJSON(steps.fetch.outputs.data).check_runs[0].id) }}
+          status: 'completed'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,28 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
+      -
+      - name: Fetch check run ids
+        id: fetch
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{repo}/actions/runs/{run_id}/jobs
+          repo: ${{ github.repository }}
+          run_id: ${{ github.run_id }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Echo check run ids
+        run: echo "job ids - ${{ toJSON(fromJSON(steps.fetch.outputs.data).jobs.*.id) }}
+
       - name: Confirm check
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          conclusion: 'success'
+          conclusion: 'neutral'
           name: 'deploy-tunnel'
           status: 'completed'
+
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Confirm check
-        uses: maael/confirm-checks-action
+        uses: maael/confirm-checks-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           commit: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,14 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy and tunnel
-        uses: wikiteq/compose-deploy-tunnel-action@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          secret: ${{ secrets.BORE_TOKEN }}
-          endpoint: stage-deploy.wikiteq.com
-          port: 80
-          file: docker-compose.yml
+      - name: Test
+        run: echo ${{ secrets.BORE_TOKEN }}
+        shell: bash
+#      - name: Deploy and tunnel
+#        uses: wikiteq/compose-deploy-tunnel-action@master
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          secret: ${{ secrets.BORE_TOKEN }}
+#          endpoint: stage-deploy.wikiteq.com
+#          port: 80
+#          file: docker-compose.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       checks: write
     runs-on: ubuntu-latest
     steps:
-      -
+
       - name: Fetch check run ids
         id: fetch
         uses: octokit/request-action@v2.x

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,15 +15,16 @@ jobs:
       pull-requests: write
       actions: write
       statuses: write
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - name: Confirm check
-        uses: maael/confirm-checks-action@main
+        uses: LouisBrunner/checks-action@v1.1.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          commit: ${{github.event.pull_request.head.sha || github.sha}}
-          repo: ${{ github.repository }}
-          checks: 'deploy-tunnel'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion: 'success'
+          name: 'deploy-tunnel'
+          status: 'in_progress'
       - name: Deploy and tunnel
         uses: wikiteq/compose-deploy-tunnel-action@master
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - MW_MAIN_CACHE_TYPE
       - MW_LOAD_SKINS=${MW_LOAD_SKINS:-Vector,chameleon}
       - MW_DEFAULT_SKIN=${MW_DEFAULT_SKIN:-chameleon}
-      - MW_LOAD_EXTENSIONS=${MW_LOAD_EXTENSIONS:-ParserFunctions,WikiEditor,VisualEditor}
+      - MW_LOAD_EXTENSIONS=${MW_LOAD_EXTENSIONS:-ParserFunctions,WikiEditor}
       - MW_ENABLE_EMAIL
       - MW_ENABLE_USER_EMAIL
       - MW_EMERGENCY_CONTACT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - MW_MAIN_CACHE_TYPE
       - MW_LOAD_SKINS=${MW_LOAD_SKINS:-Vector,chameleon}
       - MW_DEFAULT_SKIN=${MW_DEFAULT_SKIN:-chameleon}
-      - MW_LOAD_EXTENSIONS=${MW_LOAD_EXTENSIONS:-ParserFunctions,WikiEditor}
+      - MW_LOAD_EXTENSIONS=${MW_LOAD_EXTENSIONS:-ParserFunctions,WikiEditor,VisualEditor}
       - MW_ENABLE_EMAIL
       - MW_ENABLE_USER_EMAIL
       - MW_EMERGENCY_CONTACT


### PR DESCRIPTION
This is a test PR, it will be deployed by the DeployerBot workflow action as soon as it gets labelled by `deploy` label. 

* The workflow will deploy the stack on Github VM and will tunnel it through Ngrok to make it accessible from the outside.
* The deployment will stay alive for ~1h and then will be terminated
* The deployment will only be performed if the PR author has `write` permission on the repository
* You can cancel or re-trigger the workflow to initiate re-deployment
* Re-deployment will also automatically happen on new changes pushed to the PR, invalidating previous deployment first
* DeployerBot uses `.env.ci` to deploy stack instance, find sample admin credentials there

Limitations:

* The workflow uses Ngrok to tunnel web ports, the free version has limitation on 1 tunnel active at time, thus the workflow is set to use concurrency and won't be able to spin up more than one testing environment at time

Features:
* Since it spins up the whole stack on a GitHub VM the workflow will stay `In progress` until expired or cancelled, thus it's okay to see a yellow status down below, it basically means the server is up and running

Click the `View deployment` button to get excited!